### PR TITLE
Set up a simple websocket server example 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# Ignore the out of source build directory
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(SmartNodeServer
+        VERSION 0.1.0
+        DESCRIPTION "Websocket server for SmartNodes and SmartNode UIs"
+        HOMEPAGE_URL "https://github.com/PhantomGrazzler/SmartNodeServer"
+        LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Let Conan do it's magic.
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+# Options to add compiler warning flags, and turn on warnings as errors
+if(MSVC)
+    add_compile_options(/W4 /WX)
+else()
+    add_compile_options(-Wall -Wextra -pedantic -Werror)
+endif()
+
+# Main application executable
+add_executable(smartnode-server)
+target_sources(smartnode-server
+    PRIVATE src/main.cpp)
+target_link_libraries(smartnode-server
+    PRIVATE CONAN_PKG::boost)
+
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # SmartNodeServer
-C++ websocket server for SmartNodes
+C++ websocket server for SmartNodes written using boost::beast.
+
+## Building SmartNodeServer
+SmartNodeServer uses Conan and CMake. The instructions below contain example commands for building a Debug executable using a multi-configuration generator such as Visual Studio.
+
+1. Clone this repository: ```git clone https://github.com/PhantomGrazzler/SmartNodeServer.git```
+2. Create a build directory, _e.g._ ```mkdir build && cd build```
+3. Install dependencies: ```conan install .. -s build_type=Debug```
+4. Run the CMake configure step: ```cmake ..```
+5. Build the server using CMake: ```cmake --build . --config=Debug```
+
+*Note:* There is a known issue in boost::beast that code will not compile in Release mode when using Visual Studio (see https://github.com/boostorg/beast/issues/1582).
+
+## Project layout
+[The Pitchfork Layout](https://api.csswg.org/bikeshed/?force=1&url=https://raw.githubusercontent.com/vector-of-bool/pitchfork/develop/data/spec.bs) is used for this project.

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,5 @@
+[requires]
+boost/1.70.0@conan/stable
+
+[generators]
+cmake


### PR DESCRIPTION
Set up a simple websocket server example (from boost::beast 1.70 documentation) to be built using Conan and CMake.

Fails in Release mode due to an issue in boost.