### PR TITLE
Set up travis ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
           env:
             - CMAKE_COMPILER=clang++
             - CONAN_COMPILER=clang
-            - CONAN_COMPILER_VERSION=7
+            - CONAN_COMPILER_VERSION=7.0
 
 install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,30 @@ language: python
 python: "3.7"
 dist: xenial
 compiler:
-  - gcc
+    - gcc
 install:
+
     # Install conan
     - pip install conan
     # Automatic detection of your arch, compiler, etc.
     - conan user
+
+    # Install updated CMake
+    # first we create a directory for the CMake binaries
+    - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
+    - mkdir ${DEPS_DIR} && cd ${DEPS_DIR}
+    # we use wget to fetch the cmake binaries
+    - travis_retry wget --no-check-certificate https://github.com/Kitware/CMake/releases/download/v3.14.3/cmake-3.14.3-Linux-x86_64.tar.gz
+    # extract the binaries; the output here is quite lengthy,
+    # so we swallow it to not clutter up the travis console
+    - tar -xvf cmake-3.14.3-Linux-x86_64.tar.gz > /dev/null
+    - mv cmake-3.14.3-Linux-x86_64 cmake-install
+    # add both the top-level directory and the bin directory from the archive
+    # to the system PATH. By adding it to the front of the path we hide the
+    # preinstalled CMake with our own.
+    - PATH=${DEPS_DIR}/cmake-install:${DEPS_DIR}/cmake-install/bin:$PATH
+    # don't forget to switch back to the main build directory once you are done
+    - cd ${TRAVIS_BUILD_DIR}
 script:
     - mkdir build
     - cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,18 @@
-os: linux
 language: python
 python: "3.7"
-dist: xenial
-compiler:
-    - gcc
+
+matrix:
+    include:
+        - os: linux
+          dist: xenial
+          compiler: gcc
+          env: COMPILER=g++
+
+        - os: linux
+          dist: xenial
+          compiler: clang
+          env: COMPILER=clang++
+
 install:
 
     # Install conan
@@ -11,7 +20,8 @@ install:
     # Automatic detection of your arch, compiler, etc.
     - conan user
 
-    # Install updated CMake
+    # Install CMake v3.14.3
+    # Taken from https://riptutorial.com/cmake/example/4723/configure-travis-ci-with-newest-cmake
     # first we create a directory for the CMake binaries
     - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
     - mkdir ${DEPS_DIR} && cd ${DEPS_DIR}
@@ -27,11 +37,12 @@ install:
     - PATH=${DEPS_DIR}/cmake-install:${DEPS_DIR}/cmake-install/bin:$PATH
     # don't forget to switch back to the main build directory once you are done
     - cd ${TRAVIS_BUILD_DIR}
+
 script:
     - mkdir build
     - cd build
     # Download dependencies and build project
     - conan install .. -s build_type=Debug
     # Call your build system
-    - cmake .. -G "Unix Makefiles"
+    - cmake -DCMAKE_CXX_COMPILER=${COMPILER} ..
     - cmake --build . --config Debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,16 @@ matrix:
         - os: linux
           dist: xenial
           compiler: gcc
-          env: COMPILER=g++
+          env:
+            - CMAKE_COMPILER=g++
+            - CONAN_COMPILER=gcc
 
         - os: linux
           dist: xenial
           compiler: clang
-          env: COMPILER=clang++
+          env:
+            - CMAKE_COMPILER=clang++
+            - CONAN_COMPILER=clang
 
 install:
 
@@ -42,7 +46,7 @@ script:
     - mkdir build
     - cd build
     # Download dependencies and build project
-    - conan install .. -s build_type=Debug
+    - conan install .. -s build_type=Debug -s compiler=${CONAN_COMPILER}
     # Call your build system
-    - cmake -DCMAKE_CXX_COMPILER=${COMPILER} ..
+    - cmake -DCMAKE_CXX_COMPILER=${CMAKE_COMPILER} ..
     - cmake --build . --config Debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
           env:
             - CMAKE_COMPILER=g++
             - CONAN_COMPILER=gcc
+            - CONAN_COMPILER_VERSION=5
 
         - os: linux
           dist: xenial
@@ -16,6 +17,7 @@ matrix:
           env:
             - CMAKE_COMPILER=clang++
             - CONAN_COMPILER=clang
+            - CONAN_COMPILER_VERSION=7
 
 install:
 
@@ -46,7 +48,7 @@ script:
     - mkdir build
     - cd build
     # Download dependencies and build project
-    - conan install .. -s build_type=Debug -s compiler=${CONAN_COMPILER} -s compiler.libcxx=libstdc++
+    - conan install .. -s build_type=Debug -s compiler=${CONAN_COMPILER} -s compiler.libcxx=libstdc++ -s compiler.version=${CONAN_COMPILER_VERSION}
     # Call your build system
     - cmake -DCMAKE_CXX_COMPILER=${CMAKE_COMPILER} ..
     - cmake --build . --config Debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
     - mkdir build
     - cd build
     # Download dependencies and build project
-    - conan install .. -s build_type=Debug -s compiler=${CONAN_COMPILER}
+    - conan install .. -s build_type=Debug -s compiler=${CONAN_COMPILER} -s compiler.libcxx=libstdc++
     # Call your build system
     - cmake -DCMAKE_CXX_COMPILER=${CMAKE_COMPILER} ..
     - cmake --build . --config Debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+os: linux
+language: python
+python: "3.7"
+dist: xenial
+compiler:
+  - gcc
+install:
+    # Install conan
+    - pip install conan
+    # Automatic detection of your arch, compiler, etc.
+    - conan user
+script:
+    - mkdir build
+    - cd build
+    # Download dependencies and build project
+    - conan install .. -s build_type=Debug
+    # Call your build system
+    - cmake .. -G "Unix Makefiles"
+    - cmake --build . --config Debug

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # SmartNodeServer
+
+[![Build Status](https://travis-ci.com/PhantomGrazzler/SmartNodeServer.svg?branch=master)](https://travis-ci.com/PhantomGrazzler/SmartNodeServer)
+
 C++ websocket server for SmartNodes written using boost::beast.
 
 ## Building SmartNodeServer

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ SmartNodeServer uses Conan and CMake. The instructions below contain example com
 2. Create a build directory, _e.g._ ```mkdir build && cd build```
 3. Install dependencies: ```conan install .. -s build_type=Debug```
 4. Run the CMake configure step: ```cmake ..```
-5. Build the server using CMake: ```cmake --build . --config=Debug```
+5. Build the server using CMake: ```cmake --build . --config Debug```
 
 *Note:* There is a known issue in boost::beast that code will not compile in Release mode when using Visual Studio (see https://github.com/boostorg/beast/issues/1582).
 


### PR DESCRIPTION
Set up Travis CI to build code on Linux using both gcc and clang, and added a build status display image to the readme.