### PR TITLE
Issue #17 Prevent the same IP/port combination from claiming multiple peer IDs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,7 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
+
+# Settings for the VS Editor Guidelines extension
+guidelines = 120
+guidelines_style = 1px dashed white

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-# Options to add compiler warning flags, and turn on warnings as errors
+# Options to add compiler warning flags, and turn on warnings as errors.
 if(MSVC)
     add_compile_options(/W4 /WX)
     add_compile_definitions(
@@ -25,7 +25,10 @@ else()
     add_compile_options(-Wall -Wextra -pedantic -Werror)
 endif()
 
-# Main application executable
+# Copy editorconfig into the build directory so that IDEs will use those settings.
+configure_file(.editorconfig .editorconfig COPYONLY)
+
+# Main application executable.
 add_executable(smartnode-server)
 
 target_include_directories(smartnode-server

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ target_sources(smartnode-server
             src/MessageEngine.hpp
             src/MessageEngine.cpp
             src/PeerIdTypes.hpp
+            src/PeerIdTypes.cpp
     )
 
 target_link_libraries(smartnode-server

--- a/include/Session.hpp
+++ b/include/Session.hpp
@@ -1,6 +1,3 @@
-// This code is essentially the same as the asynchronous websocket server example from the boost::beast documentation.
-// See https://www.boost.org/doc/libs/1_70_0/libs/beast/example/websocket/server/async/websocket_server_async.cpp
-
 #pragma once
 
 #include "Connection.hpp"
@@ -47,6 +44,11 @@ public:
         @brief Returns the ID of the remote peer.
      */
     std::variant<UIId, NodeId> GetPeerId() const;
+
+    /*!
+        @brief Returns the ID of the remote peer as a string.
+     */
+    std::string PeerIdAsString() const;
 
 private:
     void OnAccept( boost::beast::error_code ec );

--- a/src/ConsolePrinter.hpp
+++ b/src/ConsolePrinter.hpp
@@ -14,7 +14,7 @@ namespace sns
 template<typename... T>
 void PrintWarning( T&&... items )
 {
-    ((std::cout << rang::fg::yellow) << ... << items) << rang::fg::reset << '\n';
+    ((std::cout << rang::fg::yellow << "[WARNING] ") << ... << items) << rang::fg::reset << '\n';
 }
 
 /*!
@@ -24,7 +24,7 @@ void PrintWarning( T&&... items )
 template<typename... T>
 void PrintError( T&&... items )
 {
-    ((std::cout << rang::fg::red) << ... << items) << rang::fg::reset << '\n';
+    ((std::cout << rang::fg::red << "[ERROR] ") << ... << items) << rang::fg::reset << '\n';
 }
 
 /*!
@@ -34,7 +34,7 @@ void PrintError( T&&... items )
 template<typename... T>
 void PrintInfo( T&&... items )
 {
-    ((std::cout << rang::fg::cyan) << ... << items) << rang::fg::reset << '\n';
+    ((std::cout << rang::fg::cyan << "[INFO] ") << ... << items) << rang::fg::reset << '\n';
 }
 
 /*!

--- a/src/Listener.cpp
+++ b/src/Listener.cpp
@@ -6,7 +6,6 @@
 #include <boost/beast/core.hpp>
 #include <boost/beast/websocket.hpp>
 
-#include <iostream>
 #include <memory>
 
 namespace sns

--- a/src/MessageEngine.cpp
+++ b/src/MessageEngine.cpp
@@ -48,6 +48,25 @@ void RemoveDisconnectedPeer(T& container, const U id)
     }
 }
 
+template<typename T>
+bool SessionInContainer(
+    const std::shared_ptr<Session>& pSession,
+    const T& container )
+{
+    return std::find_if( container.cbegin(), container.cend(),
+        [&pSession]( const auto& connection )
+        {
+            return connection.Session().lock() == pSession;
+        } ) != container.cend();
+}
+
+bool MessageEngine::PeerAlreadyConnected(
+    const std::shared_ptr<Session>& pSession ) const
+{
+    return SessionInContainer( pSession, m_uiConnections ) ||
+        SessionInContainer( pSession, m_nodeConnections );
+}
+
 void MessageEngine::MessageReceived(
     std::weak_ptr<Session>&& pSession,
     const std::string& message )
@@ -57,22 +76,47 @@ void MessageEngine::MessageReceived(
         const nlohmann::json msg = nlohmann::json::parse( message );
         const auto& msgType = msg.at( "MsgType" );
         PrintDebug( "Message Type is ", msgType );
+        const auto pLockedSession = pSession.lock();
+
+        if ( pLockedSession == nullptr )
+        {
+            return;
+        }
 
         if( msgType == "ui_connect" )
         {
             const UIId& id = msg.at( "UIId" );
-            PrintInfo( id, " connected" );
-            pSession.lock()->SetPeerId( id );
-            AddConnection( std::move( pSession ), id );
+
+            if ( PeerAlreadyConnected( pLockedSession ) )
+            {
+                // TODO: Respond with error.
+                PrintWarning( pLockedSession->PeerIdAsString(), " attempting to connect as ", id );
+            }
+            else
+            {
+                pLockedSession->SetPeerId( id );
+                AddConnection( std::move( pSession ), id );
+
+                PrintInfo( id, " connected" );
+            }
         }
         else if( msgType == "node_connect" )
         {
             const NodeId& id = msg.at( "NodeId" );
-            PrintInfo( id, " connected" );
-            pSession.lock()->SetPeerId( id );
-            AddConnection( std::move( pSession ), id );
 
-            ForwardMessageToUIs( message );
+            if ( PeerAlreadyConnected( pLockedSession ) )
+            {
+                // TODO: Respond with error.
+                PrintWarning( pLockedSession->PeerIdAsString(), " attempting to connect as ", id );
+            }
+            else
+            {
+                pLockedSession->SetPeerId( id );
+                AddConnection( std::move( pSession ), id );
+                PrintInfo( id, " connected" );
+
+                ForwardMessageToUIs( message );
+            }
         }
     }
     catch( const nlohmann::json::exception & e )

--- a/src/MessageEngine.cpp
+++ b/src/MessageEngine.cpp
@@ -14,6 +14,22 @@ namespace sns
 {
 
 /*!
+    @brief Builds an error message with the provided error message.
+    @param[in] errorMsg The error message to include in the response.
+ */
+std::string BuildErrorResponse( const std::string& errorMsg )
+{
+    nlohmann::json errorResp;
+
+    errorResp["MsgType"] = "error";
+    errorResp["ErrorMsg"] = errorMsg;
+
+    return errorResp.dump( 2 );
+}
+
+const auto alreadyConnectedResponse = BuildErrorResponse( "Already connected with a different ID." );
+
+/*!
     @brief Removes any expired sessions from the provided container.
     @param[in] container The container from which to remove expired sessions.
  */
@@ -89,7 +105,8 @@ void MessageEngine::MessageReceived(
 
             if ( PeerAlreadyConnected( pLockedSession ) )
             {
-                // TODO: Respond with error.
+                pLockedSession->SendMessage( alreadyConnectedResponse );
+
                 PrintWarning( pLockedSession->PeerIdAsString(), " attempting to connect as ", id );
             }
             else
@@ -106,7 +123,8 @@ void MessageEngine::MessageReceived(
 
             if ( PeerAlreadyConnected( pLockedSession ) )
             {
-                // TODO: Respond with error.
+                pLockedSession->SendMessage( alreadyConnectedResponse );
+
                 PrintWarning( pLockedSession->PeerIdAsString(), " attempting to connect as ", id );
             }
             else

--- a/src/MessageEngine.hpp
+++ b/src/MessageEngine.hpp
@@ -35,6 +35,9 @@ public:
         std::weak_ptr<Session>&& pSession );
 
 private: // methods
+    bool PeerAlreadyConnected(
+        const std::shared_ptr<Session>& pSession ) const;
+
     /*!
         @brief Adds a new connection to one of the collections of active connections, if not already present. Will also
                remove any expired UI sessions.

--- a/src/MessageEngine.hpp
+++ b/src/MessageEngine.hpp
@@ -35,6 +35,11 @@ public:
         std::weak_ptr<Session>&& pSession );
 
 private: // methods
+    /*!
+        @brief Returns true if the provided session represents a peer that has already
+               sent a connect message (either UI or node).
+        @param[in] pSession The session to test.
+     */
     bool PeerAlreadyConnected(
         const std::shared_ptr<Session>& pSession ) const;
 

--- a/src/PeerIdTypes.cpp
+++ b/src/PeerIdTypes.cpp
@@ -1,0 +1,19 @@
+#include "PeerIdTypes.hpp"
+
+#include <cstdint>
+#include <ostream>
+
+namespace sns
+{
+
+std::ostream& operator<<( std::ostream& os, const UIId id )
+{
+    return os << "UI " << static_cast<uint32_t>(id);
+}
+
+std::ostream& operator<<( std::ostream& os, const NodeId id )
+{
+    return os << "Node " << static_cast<uint32_t>(id);
+}
+
+}

--- a/src/PeerIdTypes.hpp
+++ b/src/PeerIdTypes.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <cstdint>
-#include <ostream>
+#include <iosfwd>
 
 namespace sns
 {
@@ -9,14 +8,7 @@ namespace sns
 enum class UIId{};
 enum class NodeId{};
 
-std::ostream& operator<<( std::ostream& os, const UIId id )
-{
-    return os << "UI " << static_cast<uint32_t>(id);
-}
-
-std::ostream& operator<<( std::ostream& os, const NodeId id )
-{
-    return os << "Node " << static_cast<uint32_t>(id);
-}
+std::ostream& operator<<( std::ostream& os, const UIId id );
+std::ostream& operator<<( std::ostream& os, const NodeId id );
 
 }

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -1,6 +1,7 @@
 #include "Session.hpp"
 #include "ConsolePrinter.hpp"
 #include "MessageEngine.hpp"
+#include "PeerIdTypes.hpp"
 
 #include <nlohmann/json.hpp>
 
@@ -61,6 +62,26 @@ void Session::SendMessage( const std::string& message )
 std::variant<UIId, NodeId> Session::GetPeerId() const
 {
     return m_peerId;
+}
+
+std::string Session::PeerIdAsString() const
+{
+    std::ostringstream oss;
+
+    if ( std::holds_alternative<UIId>( m_peerId ) )
+    {
+        oss << std::get<UIId>( m_peerId );
+        return oss.str();
+    }
+    else if ( std::holds_alternative<NodeId>( m_peerId ) )
+    {
+        oss << std::get<NodeId>( m_peerId );
+        return oss.str();
+    }
+    else
+    {
+        return "[No peer ID set]";
+    }
 }
 
 void Session::OnAccept( boost::beast::error_code ec )

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -124,7 +124,7 @@ void Session::OnRead(
         PrintError( "OnRead", ec.message() );
     }
 
-    PrintInfo( "Received ", bytes_transferred, " bytes" );
+    PrintDebug( "Received ", bytes_transferred, " bytes" );
 
     std::stringstream ss;
     ss << boost::beast::make_printable( m_buffer.data() );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-#include "Session.hpp"
+
 #include "Listener.hpp"
 #include "ConsolePrinter.hpp"
 #include "MessageEngine.hpp"


### PR DESCRIPTION
Implemented detection of, and response to, a peer that has already sent a "ui_connect" or "node_connect" message attempting to do so again.

**Other changes**
* Updated .editorconfig to contain settings for the VS extension Editor Guidelines.
* Added step to CMakeLists to copy .editorconfig to the build directory.

This pull request closes issue #17.